### PR TITLE
Fix return value from RdSeed_cpuid()

### DIFF
--- a/rdrand.c
+++ b/rdrand.c
@@ -162,7 +162,7 @@ RdSeed_cpuid(void)
     if ((ebx & RDSEED_MASK) == RDSEED_MASK)
         return 1;
     else
-        return info[1];
+        return 0;
 }
 
 /************************


### PR DESCRIPTION
The function returned `info[1]` (which is the content of the `ebx`
register) instead of `0` when it detected that _rdseed_ is unavailable.
This is likely a remnant from an earlier iteration of the code.

While it is unlikely that it will show up as bug (all of the bits of
`ebx` would have to be cleared, except bit #0 which would have to be
set) due to the calling function comparing the return value explicitly
with 1, it's still better to fix it.